### PR TITLE
Fix error compiling with Cocoa/OSX (unknown object NSWindow)

### DIFF
--- a/sdl2/sdl_syswm.nim
+++ b/sdl2/sdl_syswm.nim
@@ -211,7 +211,7 @@ else:
   elif defined(SDL_VIDEO_DRIVER_COCOA):
     type
       SysWMinfoCocoaObj* = object
-        window*: ptr NSWindow ## The Cocoa window
+        window*: pointer ## The Cocoa window
 
       SysWMinfoKindObj* = object
         cocoa*: SysWMinfoCocoaObj


### PR DESCRIPTION
One liner: NSWindow, the Cocoa window object, is not known (and does not need to be known to the wrapper). There are no other references to NS* objects.

Swapped with pointer type, now compiles with nim 0.16.0, OS X 10.9.5


