### PR TITLE
iterator events

### DIFF
--- a/sdl2/private/events.nim
+++ b/sdl2/private/events.nim
@@ -678,3 +678,9 @@ proc registerEvents*(numevents: cint): uint32 {.
   ##
   ##  If there aren't enough user-defined events left, this procedure
   ##  returns `-1'u32`.
+
+iterator events*(): sdl.Event =
+  ## Iterate through and consume the event queue.
+  var event: sdl.Event
+  while pollEvent(event.addr) != 0:
+    yield event


### PR DESCRIPTION
There is a good reason not to add this iterator, because it is not part of the official SDL library. But it is simply said, very practical. All events could be processed like this:

```Nim
for event in events():
   case event.kind
   [...]
```