### PR TITLE
potentially breaking change?

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Includes:
 * SDL_net 2.0.1
 * SDL_ttf 2.0.14
 
-What does not implemented here:
+What is not implemented here:
 -------------------------------
 
 * OpenGL headers (use [opengl](https://github.com/nim-lang/opengl) lib instead)
@@ -37,17 +37,17 @@ d     - sdl2_nim revision
 
 FAQ:
 ====
-**Q**: Why it exist if there's official [nim-lang/sdl2](https://github.com/nim-lang/sdl2) repository?
+**Q**: Why does this exist if there's an official [nim-lang/sdl2](https://github.com/nim-lang/sdl2) repository?
 
-**A**: This wrapper is actually was created before the official (Aug.2013 vs. Mar.2014). It may be, I wouldn't make it if there was other wrapper at the time.
+**A**: This wrapper actually was created before the official (Aug. 2013 vs. Mar. 2014). Maybe I wouldn't have made it if there already was a wrapper at the time.
 
-**Q**: How it is different from the official wrapper?
+**Q**: How is it different from the official wrapper?
 
 **A**: Obviously, it can't be *much* different, as they both are wrappers for the same library, but what comes to mind:
 
 * This one is fully documented, nim-style, with the generated documentation as a bonus;
 * I personally created a series of highly commented examples for almost every aspect of the library and its "satelites" (gfx, ttf, etc.);
-* Design decisions that I thought made more sence than official one's (like Event type through {.union.} vs. evConv template with casting; naming sceme closer to the original sdl2, etc.);
+* Design decisions that I thought made more sense than official one's (like Event type through {.union.} vs. evConv template with casting; naming sceme closer to the original sdl2, etc.);
 * Source files' structure is closely following the original library.
 
 **Q**: Why should I use this one vs. the official?
@@ -101,4 +101,3 @@ CHANGELOG:
 * added SDL2-net
 * added event convertion templates
 * different fixes
-

--- a/sdl2/private/joystick.nim
+++ b/sdl2/private/joystick.nim
@@ -248,7 +248,7 @@ proc joystickGetAxis*(joystick: Joystick; axis: cint): int16 {.
   ##
   ##  The axis indices start at index `0`.
 
-proc  joystickGetAxisInitialState(joystick: Joystick, axis: cint, state: ptr int16): cint {.
+proc joystickGetAxisInitialState*(joystick: Joystick, axis: cint, state: ptr int16): cint {.
     cdecl, importc: "SDL_JoystickGetAxisInitialState", dynlib: SDL2_LIB.}
   ##  Get the initial state of an axis control on a joystick.
   ##
@@ -325,4 +325,3 @@ proc joystickClose*(joystick: Joystick) {.
 proc joystickCurrentPowerLevel*(joystick: Joystick): JoystickPowerLevel {.
     cdecl, importc: "SDL_JoystickCurrentPowerLevel", dynlib: SDL2_LIB.}
   ##  Return the battery level of this ``joystick``.
-

--- a/sdl2/private/pixels.nim
+++ b/sdl2/private/pixels.nim
@@ -265,12 +265,7 @@ else:
     PIXELFORMAT_ABGR32* = PIXELFORMAT_RGBA8888
 
 type
-  Color* = object
-    r*: uint8
-    g*: uint8
-    b*: uint8
-    a*: uint8
-
+  Color* = tuple[r, g, b, a: uint8]
   Colour* = Color
 
 type
@@ -412,7 +407,6 @@ proc getRGB*(pixel: uint32; format: ptr PixelFormat;
   ##  ``getRGBA()``
 
 proc getRGB*(pixel: uint32, format: ptr PixelFormat): Color {.inline.} =
-  result = Color()
   getRGB(pixel, format,
     addr(result.r), addr(result.g), addr(result.b))
 
@@ -426,7 +420,6 @@ proc getRGBA*(pixel: uint32; format: ptr PixelFormat;
   ##  ``getRGB()``
 
 proc getRGBA*(pixel: uint32, format: ptr PixelFormat): Color {.inline.} =
-  result = Color()
   getRGBA(pixel, format,
     addr(result.r), addr(result.g), addr(result.b), addr(result.a))
 

--- a/sdl2/private/pixels.nim
+++ b/sdl2/private/pixels.nim
@@ -265,7 +265,12 @@ else:
     PIXELFORMAT_ABGR32* = PIXELFORMAT_RGBA8888
 
 type
-  Color* = tuple[r, g, b, a: uint8]
+  Color* = object
+    r*: uint8
+    g*: uint8
+    b*: uint8
+    a*: uint8
+
   Colour* = Color
 
 type
@@ -407,6 +412,7 @@ proc getRGB*(pixel: uint32; format: ptr PixelFormat;
   ##  ``getRGBA()``
 
 proc getRGB*(pixel: uint32, format: ptr PixelFormat): Color {.inline.} =
+  result = Color()
   getRGB(pixel, format,
     addr(result.r), addr(result.g), addr(result.b))
 
@@ -420,6 +426,7 @@ proc getRGBA*(pixel: uint32; format: ptr PixelFormat;
   ##  ``getRGB()``
 
 proc getRGBA*(pixel: uint32, format: ptr PixelFormat): Color {.inline.} =
+  result = Color()
   getRGBA(pixel, format,
     addr(result.r), addr(result.g), addr(result.b), addr(result.a))
 

--- a/sdl2/private/video.nim
+++ b/sdl2/private/video.nim
@@ -243,8 +243,8 @@ const # GLcontextReleaseFlag
   GL_CONTEXT_RELEASE_BEHAVIOUR_FLUSH* = 0x0001
 
 const # GLcontextResetNotification*
-  GL_CONTEXT_RESET_NO_NOTIFICATION    = 0x0000
-  GL_CONTEXT_RESET_LOSE_CONTEXT       = 0x0001
+  GL_CONTEXT_RESET_NO_NOTIFICATION*   = 0x0000
+  GL_CONTEXT_RESET_LOSE_CONTEXT*      = 0x0001
 
 
 # Procedure prototypes

--- a/sdl2/sdl_gpu.nim
+++ b/sdl2/sdl_gpu.nim
@@ -1197,7 +1197,7 @@ proc setTargetRGB*(target: Target; r, g, b: uint8) {.
 
 proc setTargetRGBA*(target: Target; r, g, b, a: uint8) {.
     cdecl, importc: "GPU_SetTargetRGBA", dynlib: SDL2_GPU_LIB.}
-  ##  Sets the modulation color for subsequent drawing of images and shapes on the given target. 
+  ##  Sets the modulation color for subsequent drawing of images and shapes on the given target.
   ##  This has a cumulative effect with the image coloring functions.
   ##  e.g. setRGB(image, 255, 128, 0); setTargetRGB(target, 128, 128, 128);
   ##  Would make the image draw with color of roughly (128, 64, 0).
@@ -1213,17 +1213,17 @@ proc unsetTargetColor*(target: Target) {.
 
 # SurfaceControls
 
-proc loadSurface*(filename: cstring): ptr Surface {.
+proc loadSurface*(filename: cstring): Surface {.
     cdecl, importc: "GPU_LoadSurface", dynlib: SDL2_GPU_LIB.}
   ##  Load surface from an image file that is supported by this renderer.
   ##  Don't forget to SDL's ``freeSurface()`` it.
 
-proc loadSurfaceRW*(rwops: ptr RWops; freeRwops: bool): ptr Surface {.
+proc loadSurfaceRW*(rwops: ptr RWops; freeRwops: bool): Surface {.
     cdecl, importc: "GPU_LoadSurface_RW", dynlib: SDL2_GPU_LIB.}
   ##  Load surface from an image file in memory.
   ##  Don't forget to SDL's ``freeSurface()`` it.
 
-proc saveSurface*(surface: ptr Surface; filename: cstring; format: FileFormat): bool {.
+proc saveSurface*(surface: Surface; filename: cstring; format: FileFormat): bool {.
     cdecl, importc: "GPU_SaveSurface", dynlib: SDL2_GPU_LIB.}
   ##  Save surface to a file.
   ##  With a format of `FILE_AUTO`, the file type is deduced from the extension.
@@ -1232,7 +1232,7 @@ proc saveSurface*(surface: ptr Surface; filename: cstring; format: FileFormat): 
   ##
   ##  ``Return`` `0` on failure.
 
-proc saveSurfaceRW*(surface: ptr Surface; rwops: ptr RWops; freeRwops: bool;
+proc saveSurfaceRW*(surface: Surface; rwops: ptr RWops; freeRwops: bool;
                    format: FileFormat): bool {.
     cdecl, importc: "GPU_SaveSurface_RW", dynlib: SDL2_GPU_LIB.}
   ##  Save surface to a ``RWops`` stream.
@@ -1303,7 +1303,7 @@ proc unsetImageVirtualResolution*(image: Image) {.
     cdecl, importc: "GPU_UnsetImageVirtualResolution", dynlib: SDL2_GPU_LIB.}
   ##  Reset the logical size of the given image to its original value.
 
-proc updateImage*(image: Image; imageRect: ptr Rect; surface: ptr Surface;
+proc updateImage*(image: Image; imageRect: ptr Rect; surface: Surface;
                   surfaceRect: ptr Rect) {.
     cdecl, importc: "GPU_UpdateImage", dynlib: SDL2_GPU_LIB.}
   ##  Update an image from surface data.
@@ -1319,7 +1319,7 @@ proc updateImageBytes*(
   ##  Ignores virtual resolution on the image
   ##  so the number of pixels needed from the surface is known.
 
-proc replaceImage*(image: Image; surface: ptr Surface; surfaceRect: ptr Rect): bool {.
+proc replaceImage*(image: Image; surface: Surface; surfaceRect: ptr Rect): bool {.
     cdecl, importc: "GPU_ReplaceImage", dynlib: SDL2_GPU_LIB.}
   ##  Update an image from surface data,
   ##  replacing its underlying texture to allow for size changes.
@@ -1426,7 +1426,7 @@ proc setWrapMode*(image: Image; wrapModeX: Wrap; wrapModeY: Wrap) {.
 
 # Surface / Image / Target conversions
 
-proc copyImageFromSurface*(surface: ptr Surface): Image {.
+proc copyImageFromSurface*(surface: Surface): Image {.
     cdecl, importc: "GPU_CopyImageFromSurface", dynlib: SDL2_GPU_LIB.}
   ##  Copy Surface data into a new image.
   ##  Don't forget to SDL's ``freeSurface()`` the surface
@@ -1437,12 +1437,12 @@ proc copyImageFromTarget*(target: Target): Image {.
   ##  Copy target data into a new image.
   ##  Don't forget to ``freeImage()`` the image.
 
-proc copySurfaceFromTarget*(target: Target): ptr Surface {.
+proc copySurfaceFromTarget*(target: Target): Surface {.
     cdecl, importc: "GPU_CopySurfaceFromTarget", dynlib: SDL2_GPU_LIB.}
   ##  Copy target data into a new ``Surface``.
   ##  Don't forget to SDL's ``freeSurface()`` the surface.
 
-proc copySurfaceFromImage*(image: Image): ptr Surface {.
+proc copySurfaceFromImage*(image: Image): Surface {.
     cdecl, importc: "GPU_CopySurfaceFromImage", dynlib: SDL2_GPU_LIB.}
   ##  Copy image data into a new ``Surface``.
   ##  Don't forget to SDL's ``freeSurface()`` the surface
@@ -2420,4 +2420,3 @@ proc setAttributeSource*(numValues: cint; source: Attribute) {.
   ##  Enables a shader attribute and sets its source data.
 
 # End of ShaderInterface
-


### PR DESCRIPTION
so commit b6e663a is a harmless but important fix and 96e1889 just fixes some typos in the readme,
7877e45 however changes the type of Color from object to tuple and I am not sure if you want to pull that.

I find that tuples are much more flexible and suitable for this kind of type.
for instance, you can pass a tuple like ``(255, 0, 0, 255)`` or optionally as ``(r: 255, g: 0, b: 0, a: 255)``, while with an object, only this would be valid: ``Color(r: 255, g: 0, b: 0, a: 255)``.

so if you pull this then existing projects might require small adjustments.