### PR TITLE
Fix potential typo

### DIFF
--- a/sdl2/private/thread.nim
+++ b/sdl2/private/thread.nim
@@ -101,7 +101,7 @@ when hostOS == "windows":
 
   proc createThreadWithStackSize_internal(
       fn: ThreadFunction; name: cstring; stacksize: csize; data: pointer;
-      cbegin: CurrentBeginThread; cend: CurrentEndThreada): Thread {.
+      cbegin: CurrentBeginThread; cend: CurrentEndThread): Thread {.
         cdecl, importc: "SDL_CreateThreadWithStackSize".}
 
   proc createThreadWithStackSize*(


### PR DESCRIPTION
I found this running a `nim check --os:windows` on my code.  Is this a typo?