### PR TITLE
Fix illegal integer conversion

### DIFF
--- a/sdl2/private/touch.nim
+++ b/sdl2/private/touch.nim
@@ -36,7 +36,7 @@ type
     pressure*: cfloat
 
 const
-  TOUCH_MOUSEID* = uint32(-1) ##  \
+  TOUCH_MOUSEID* = cast[uint32](-1'i32) ##  \
     ##  Used as the device ID for mouse events simulated with touch input
 
 # Procedures


### PR DESCRIPTION
Hello,

I've been reviving an old Nim PR (https://github.com/nim-lang/Nim/pull/7164) that enforces stricter checks for integer/float conversions during compile time. This additional check means that compile time conversion of negative integers to unsigned integers will no longer be allowed. Nim's CI found an illegal conversion in this package so here's a fix.