### PR TITLE
Add when blocks to handle various vulkan packages

### DIFF
--- a/sdl2/private/vulkan.nim
+++ b/sdl2/private/vulkan.nim
@@ -35,7 +35,14 @@
 # VK_DEFINE_HANDLE(VkInstance)
 # VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSurfaceKHR)
 
-# Avoid including vulkan.h, don't define VkInstance if it's already included
+when defined(vulkanim) or defined(vkDynlib): # import vulkanim/vulkan expecting availability of something like https://github.com/Clyybber/vulkanim
+  from vulkanim/vulkan import VkInstance, VkSurfaceKHR
+elif defined(vulkan): # import just vulkan expecting availability of something like https://github.com/nimgl/vulkan
+  from vulkan import VkInstance, VkSurfaceKHR
+elif defined(nimglvulkan): #import nimgl/vulkan expecting availability of something like https://github.com/nimgl/nimgl vulkan subpackage
+  from nimgl/vulkan import VkInstance, VkSurfaceKHR
+
+# Avoid including vulkan.h, don't define VkInstance if it's already included and we do not know if any available module will provide it
 when not declared(VkInstance):
   type
     VkInstance* = pointer

--- a/sdl2_nim/private/vulkan.nim
+++ b/sdl2_nim/private/vulkan.nim
@@ -35,7 +35,14 @@
 # VK_DEFINE_HANDLE(VkInstance)
 # VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSurfaceKHR)
 
-# Avoid including vulkan.h, don't define VkInstance if it's already included
+when defined(vulkanim) or defined(vkDynlib): # import vulkanim/vulkan expecting availability of something like https://github.com/Clyybber/vulkanim
+  from vulkanim/vulkan import VkInstance, VkSurfaceKHR
+elif defined(vulkan): # import just vulkan expecting availability of something like https://github.com/nimgl/vulkan
+  from vulkan import VkInstance, VkSurfaceKHR
+elif defined(nimglvulkan): #import nimgl/vulkan expecting availability of something like https://github.com/nimgl/nimgl vulkan subpackage
+  from nimgl/vulkan import VkInstance, VkSurfaceKHR
+
+# Avoid including vulkan.h, don't define VkInstance if it's already included and we do not know if any available module will provide it
 when not declared(VkInstance):
   type
     VkInstance* = pointer


### PR DESCRIPTION
Small fixes to not use stubbed pointers but rather the real types of some packages when some indicator it exists has been given.

Takes a similar approach to nimgl and their GLFW packages by detecting
compile time defines to indicate which library should provide vulkan
symbols.

Tested successfully with [vulkanim](https://github.com/Clyybber/vulkanim).